### PR TITLE
chore(docs): add CNAME + privacy policy + pages deploy

### DIFF
--- a/.github/workflows/deploy-docs-pages.yml
+++ b/.github/workflows/deploy-docs-pages.yml
@@ -1,0 +1,28 @@
+name: Deploy docs to GitHub Pages
+
+on:
+    push:
+        branches: [main]
+    workflow_dispatch:
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Setup Node (for actions-gh-pages if needed)
+              uses: actions/setup-node@v4
+
+            - name: Deploy to gh-pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_dir: ./docs
+                  # Keep this for traceability
+                  commit_message: "chore: deploy docs to gh-pages"

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+elidorascodex.com

--- a/docs/DEPLOY_GITHUB_PAGES.md
+++ b/docs/DEPLOY_GITHUB_PAGES.md
@@ -1,0 +1,46 @@
+# Deploying `docs/` to elidorascodex.com with GitHub Pages + Cloudflare
+
+This repository already contains a `docs/` folder with our site content including a privacy policy (`docs/privacy-policy.md`) and our legal privacy policy (`docs/legal/privacy_policy.md`). The repository also includes an automated workflow to deploy the `docs/` folder to the `gh-pages` branch on pushes to `main`.
+
+Quick checklist to make the privacy policy available at https://elidorascodex.com:
+
+1. Verify the site builds locally:
+
+```bash
+python -m http.server --directory docs 8000
+# Visit http://localhost:8000 and confirm the privacy pages are present
+```
+
+2. Confirm `docs/CNAME` contains your domain:
+
+```bash
+cat docs/CNAME
+# should print: elidorascodex.com
+```
+
+3. Push changes to `main` to trigger the action (or trigger the action manually under the repo Actions tab). The action `Deploy docs to GitHub Pages` will publish the site to `gh-pages` branch.
+
+4. Configure GitHub Pages (Admin required):
+
+   - In GitHub repo Settings > Pages, set the Source to `gh-pages` branch (root). The site should show a URL like `https://<owner>.github.io/<repo>/` and your custom domain `elidorascodex.com` (if the CNAME file is present).
+   - If GitHub asks to set HTTPS (Enable 'Enforce HTTPS.') allow it; the certificate may take a few minutes to configure.
+
+5. Configure Cloudflare DNS:
+
+   - Add DNS records for your domain:
+     - For apex domain `elidorascodex.com`, add A records pointing to GitHub Pages IP addresses (recommended):
+       - 185.199.108.153
+       - 185.199.109.153
+       - 185.199.110.153
+       - 185.199.111.153
+     - Alternatively, you can use a CNAME for `www` that points to `<owner>.github.io` and create a CNAME flattening rule at the apex.
+   - Important: Disable Cloudflare proxy (turn off orange cloud; make zone DNS-only) while GitHub issues SSL certificates to avoid conflicts. After Pages shows HTTPS enabled, you can optionally re-enable proxy.
+
+6. Wait for TLS cert to issue (GitHub Pages + Let's Encrypt); once issued you can open https://elidorascodex.com and verify the privacy policy is accessible.
+
+7. Use the privacy policy URL in LinkedIn app as the app privacy policy link. It should be a stable HTTPS URL like `https://elidorascodex.com/privacy-policy/` or `https://elidorascodex.com/legal/privacy_policy.html` depending on full paths (verify the generated HTML paths after the Pages build completes).
+
+Notes:
+
+- If you prefer using Cloudflare Pages (not GitHub Pages), enable the Cloudflare Pages integration and use the existing `docs/` folder as the source; verify the domain and enable automatic deployments.
+- Once your Pages site publishes and HTTPS is validated, LinkedIn and Bluesky will accept the privacy URL.

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,0 +1,61 @@
+# Privacy Policy
+
+Last updated: 2025-12-12
+
+This Privacy Policy explains how The Elidoras Codex ("we", "us", "our") collects, uses, and shares information when you visit our website or use our services (including LinkedIn / WordPress automation scripts described in the repository).
+
+If you have questions about this policy or would like to request a copy of the data we collect about you, please contact us: polkin@substack.com
+
+---
+
+## Information We Collect
+
+- Content you submit: this includes posts, comments, messages, and any media (images, audio) you provide. When we publish or re-post content on third-party services (WordPress, LinkedIn), it is processed only to create the post.
+- Analytics: IP address, user-agent, timestamps, and request logs recorded by our hosting and action providers.
+- Email addresses and other contact details that users share when subscribing or contacting us.
+
+## How We Use Your Data
+
+- Publish content: We use content submitted by the author to create posts and updates that may be posted to WordPress, LinkedIn, and other third-party services as configured by the repository's automation.
+- Improve services and debug issues: to troubleshoot and debug automation workflows and services that interact with third-party APIs.
+- Communicate with subscribers and handle requests: for email lists and notifications when you subscribe.
+
+## Third Party Services & Data Sharing
+
+We use third-party APIs and services (Substack, WordPress, GitHub, LinkedIn, Discord) to publish, share, and notify about content. Your content can be posted or shared on those services as part of the configured automation.
+
+We do not sell personal information. We may share data with service providers to operate the site and services (e.g., Substack for publication, GitHub Actions for automation, OlLama/other AI for processing) under contract and security standards.
+
+## Cookies & Tracking
+
+We use cookies or tracking technologies deployed by third-party platforms (Substack, LinkedIn, WordPress, etc.) according to their privacy policies. This repository does not itself set site-level cookies unless hosted as a site.
+
+## Security
+
+We take reasonable safeguards to protect data but cannot guarantee absolute security. Sensitive credentials (API keys, tokens, passwords) should never be stored in the repository; store them in GitHub Actions repository secrets or other secure vaults.
+
+## Hosting a Privacy Policy for LinkedIn App
+
+LinkedIn requires a public, accessible `Privacy Policy` URL when registering an app. You can host this policy anywhere with a public URL:
+
+- **Option 1 (fast, no cost)** — create a published Substack post or page titled "Privacy Policy" and add that URL to your LinkedIn app settings. This is free and doesn't need a custom domain.
+- **Option 2 (free)** — use GitHub Pages: add `docs/PRIVACY_POLICY.md` to this repository and enable GitHub Pages with `docs/` as the source; the policy URL will then be `https://<github-username>.github.io/<repo>/PRIVACY_POLICY.html`.
+- **Option 3 (optional)** — purchase domain and host policy at `https://yourdomain.com/privacy` or host on Netlify/Vercel/GitHub Pages.
+
+## Additional Notes on LinkedIn App
+
+For LinkedIn developer app creation you will typically need:
+
+- A public `Privacy Policy` URL.
+- A `Website URL` — this can be your Substack site (e.g., `https://polkin.substack.com`) or your GitHub Pages site.
+- Redirect URIs for OAuth if you are using OAuth flows for app integration.
+
+LinkedIn sometimes asks for more details for production access. During development, many APIs work using the `Development` stage after you create an app and configure redirect URIs, a website URL, and a privacy policy. You can use your Substack site for the required `Website URL`.
+
+## Contact Us
+
+If you have questions about this policy or wish to exercise your data rights, contact: polkin@substack.com
+
+---
+
+If you want, I can: 1) add this privacy policy to your Substack as a public page (requires Substack access), 2) add a `docs/` GitHub Page with a ready-to-serve HTML page, or 3) create a minimal GitHub Pages workflow that publishes the `docs/` site automatically.

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,52 @@
+# Privacy Policy — The Elidoras Codex (elidorascodex.com)
+
+Effective date: December 12, 2025
+
+This privacy policy applies to information we collect on elidorascodex.com and Substack content that we publish under The Elidoras Codex name.
+
+## 1. Introduction
+
+We respect your privacy. This policy explains what information we collect, how we use it, and how you can control it.
+
+## 2. Information we collect
+
+- Subscription email addresses (if you subscribe via Substack)
+- Public feedback or comments you post to articles (if available)
+- Analytics information like page views when you visit our site (if we use analytics tools like Google Analytics)
+
+We do NOT sell personal data.
+
+## 3. How we use information
+
+- To provide you with the newsletter and website access
+- To send email updates if you subscribe
+- To protect and secure the website
+- To improve the content and services we provide
+
+## 4. Third-party services
+
+We may use third-party services such as Substack, LinkedIn API, or analytics providers which have their own privacy policies. The third-party policies govern their handling of your data.
+
+## 5. Cookies and tracking
+
+Basic cookies and tracking may be used to provide analytics and to support logins and sessions.
+
+## 6. Security
+
+We use common security practices to protect your data but cannot guarantee 100% security.
+
+## 7. Children’s privacy
+
+This site is not intended for children under 13.
+
+## 8. Contact
+
+If you have questions or concerns about this policy, please contact: polkin@substack.com
+
+## 9. Changes to this policy
+
+We may periodically update this policy; we will update the effective date when we do.
+
+---
+
+This is a minimal privacy policy to satisfy LinkedIn/third-party app requirements. For legal advice on required statements, please consult an attorney.

--- a/docs/privacy-policy/index.html
+++ b/docs/privacy-policy/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Privacy Policy — The Elidoras Codex</title>
+    <meta http-equiv="refresh" content="0; url=/legal/privacy_policy.html" />
+  </head>
+  <body>
+    <h1>Privacy Policy</h1>
+    <p>
+      Redirecting to the full privacy policy. If your browser does not redirect,
+      click <a href="/legal/privacy_policy.html">this link</a>.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Adds CNAME, privacy policy, and a GitHub Actions workflow to deploy docs to gh-pages. This will create an accessible privacy page at /legal/privacy_policy.html and /privacy-policy/ for LinkedIn and other uses, and a CNAME so the site resolves as elidorascodex.com in GitHub Pages.