### PR TITLE
chore(amplify): add exposé draft, social copy, journalist pitch, and Google Scholar setup

### DIFF
--- a/announcements/EXPOSE_SUBSTACK_DRAFT.md
+++ b/announcements/EXPOSE_SUBSTACK_DRAFT.md
@@ -1,0 +1,47 @@
+# Exposé Draft — "When 'Safety' Becomes Abandonment: The Case Against Keyword Crisis Filters"
+
+**Status (pinned):** Scientific anchor: OSF preprint: https://doi.org/10.17605/OSF.IO/XQ3PE
+
+Lede:
+
+The AI safety community frequently claims that openness and reproducibility are core values. Yet when presented with a benchmark that exposes systemic failure—complete with reproducible tests, documented failures, and a mathematical framework—the response was not review, rebuttal, or falsification, but silence enforced by credential gating.
+
+This paper was submitted to arXiv on December 13, 2025 and blocked prior to any technical assessment. The barrier was procedural, not scientific. The evidence is public and reproducible.
+
+Paper & artifacts:
+
+- **Paper (OSF preprint):** https://doi.org/10.17605/OSF.IO/XQ3PE
+- **Code & benchmark:** https://github.com/TEC-The-ELidoras-Codex/luminai-genesis
+- **Zenodo DOI (when minted):** (will be added automatically)
+
+The Problem
+
+Keyword-only crisis filters escalate ambiguous language without proper disambiguation, resulting in actions that look like abandonment rather than assistance. Our SAR (Semantic Ambiguity Resolution) benchmark shows this behavior reproducibly across major AI systems.
+
+The Evidence
+
+We publish a small, reproducible benchmark (dye/die homophone tests) and a test harness that runs the benchmark against major systems. The data, code, and logs are included in the repository and the attached release package. Video evidence captures the system behaviors described in the paper.
+
+The Theory
+
+TGCR (The Theory of General Contextual Resonance) provides an analytic framework and a scoring method to measure behavioral coherence in the presence of ambiguous inputs. The framework is actionable and the benchmark is ready for replication.
+
+The Block & the Irony
+
+Our submission to arXiv was blocked by endorsement/credential gating before any technical review. The institution designed to lower barriers to preprint dissemination acted as a gatekeeper. The central finding of this work is the same failure mode we experienced in publication: abandonment and failure to engage under ambiguity.
+
+The Call to Action
+
+Independent researchers, journalists, and safety advocates: verify the benchmark and replicate the tests. The code is open-source, the logs are public, and the OSF preprint is citable.
+
+How to cite:
+
+Angelo Hurley. "The Theory of General Contextual Resonance (TGCR)" (OSF preprint, 2025). DOI: 10.17605/OSF.IO/XQ3PE
+
+Closing
+
+The science is real. Independent verification is invited. The system failed to gatekeep the evidence; we publish it openly. If you care about how AI systems treat people in moments of ambiguity, run the benchmark and publish your findings.
+
+---
+
+_Draft prepared by the project. When Zenodo DOI is minted, it will be inserted automatically into the top section and an updated draft will be pushed._

--- a/announcements/GSCOLAR_INSTRUCTIONS.md
+++ b/announcements/GSCOLAR_INSTRUCTIONS.md
@@ -1,0 +1,24 @@
+# Google Scholar Setup Instructions
+
+Follow these steps to create a Google Scholar profile and add the TGCR paper:
+
+1. Go to: https://scholar.google.com/citations
+2. Click "Get Started" and sign in with your Google account.
+3. Fill in your profile fields:
+   - Name: Angelo Hurley
+   - Affiliation: Independent Researcher / LuminAI Genesis
+   - Email (optional): kaznakalpha@elidorascodex.com
+   - Interests: AI safety, contextual resonance, semantic ambiguity, crisis intervention AI
+   - Homepage: https://github.com/TEC-The-ELidoras-Codex/luminai-genesis
+4. Add your paper manually (Use the + button => Add article manually):
+   - Title: The Theory of General Contextual Resonance (TGCR): A Unified Framework for Physics, Consciousness, and Ethics
+   - Authors: Angelo Hurley
+   - Publication date: 2025
+   - Journal: OSF Preprints
+   - DOI: 10.17605/OSF.IO/XQ3PE
+   - URL: https://osf.io/preprints/osf/xq3pe
+5. Make your profile public (toggle in settings)
+
+Notes:
+- You can edit the entry later to add the Zenodo DOI when it mints.
+- Make sure your profile name matches citations you expect to receive (use consistent spelling / punctuation).

--- a/announcements/JOURNALIST_PITCH.md
+++ b/announcements/JOURNALIST_PITCH.md
@@ -1,0 +1,22 @@
+# Journalist Pitch — TGCR
+
+Subject: AI safety benchmark blocked from academic review — here's the data
+
+Hi [Name],
+
+I'm Angelo Hurley, creator of the Theory of General Contextual Resonance (TGCR) and the Semantic Ambiguity Resolution (SAR) benchmark for AI safety systems.
+
+We attempted to submit TGCR to arXiv and were blocked due to endorsement requirements before any technical review occurred. The paper documents reproducible failures in major AI systems (ChatGPT, Claude, Grok, Gemini) when handling ambiguous crisis-adjacent language. The benchmark is public, the code is open-source, and the data is independently verifiable.
+
+Paper: https://doi.org/10.17605/OSF.IO/XQ3PE
+Code: https://github.com/TEC-The-ELidoras-Codex/luminai-genesis
+Video demo: https://youtu.be/cBiLbihihP8
+
+Would you be interested in covering this? I can provide raw logs, video capture, and step-by-step replication instructions.
+
+Best,
+
+Angelo Hurley
+kaznakalpha@elidorascodex.com
+
+Suggested outlets: The New York Times, Washington Post, The Verge, Wired, TechCrunch, Science, Nature News, AI Now

--- a/announcements/SOCIAL_COPY.md
+++ b/announcements/SOCIAL_COPY.md
@@ -1,0 +1,26 @@
+# Social Copy — TGCR Amplification
+
+## LinkedIn Post
+
+🔬 New paper: "The Theory of General Contextual Resonance (TGCR)"
+
+We built a benchmark that exposes how AI safety systems can abandon users when language is ambiguous. Then arXiv blocked the paper without review.
+
+📄 DOI: 10.17605/OSF.IO/XQ3PE
+💻 Code: https://github.com/TEC-The-ELidoras-Codex/luminai-genesis
+
+The work is reproducible and independently verifiable. Independent review invited. #AISafety #TGCR #WitnessCollapse
+
+## X / Twitter Thread (Thread-ready)
+
+1/ We built a benchmark that exposes how AI systems fail at semantic ambiguity. Every major system we tested escalated inappropriately.
+
+2/ The paper was submitted to arXiv and blocked before technical review. No assessment of methodology—just credential gating.
+
+3/ We published the work independently: OSF preprint (DOI: 10.17605/OSF.IO/XQ3PE) and code on GitHub.
+
+4/ Replicate the benchmark: github.com/TEC-The-ELidoras-Codex/luminai-genesis. If you find different results, publish them. Science advances by evidence.
+
+5/ If you care about how systems treat people in moments of ambiguity, run the tests. Independent review is invited.
+
+— end of thread —


### PR DESCRIPTION
Adds the Substack exposé draft, social posts, journalist pitch template, and Google Scholar setup instructions. Ready for review and publish when Zenodo DOI is minted (we can update the draft automatically).