### PR TITLE
ci: add pre-commit & pytest workflow

### DIFF
--- a/.github/workflows/ci-precommit-tests.yml
+++ b/.github/workflows/ci-precommit-tests.yml
@@ -1,0 +1,46 @@
+name: CI — pre-commit & tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  checks:
+    name: Pre-commit & Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # Install project deps if available, but continue if requirements are incomplete
+          pip install -r requirements.txt || true
+          pip install pre-commit pytest
+
+      - name: Run pre-commit
+        run: |
+          pre-commit run --all-files
+
+      - name: Run tests
+        run: |
+          pytest -q
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-logs
+          path: |
+            ./**/pytest.log
+            ./**/coverage.xml
+            || true


### PR DESCRIPTION
Add a minimal CI job that runs pre-commit and pytest on PRs to enforce code quality and tests.

Notes:
- This will help enforce the pre-commit and test standards; the initial run may fail until the remaining lint/test issues are fixed.\n- If the job is too strict initially, we can adjust to run pre-commit in 'diff' mode or run a subset of hooks.

Checklist:
- [ ] CI runs pre-commit successfully
- [ ] CI runs pytest successfully

